### PR TITLE
Fixes

### DIFF
--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -61,7 +61,7 @@ class Tiny_Nav_Menu_Cache {
 	// define('TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS', 'XDEBUG_TRIGGER, do_xhprof_profile');
 
 	if ( defined( 'TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS' ) ) {
-		$fields = explode( ',', TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS);
+		$fields = array_map( 'trim', explode( ',', TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS) );
 		$this->whitelisted_query_string_fields = array_merge( $this->whitelisted_query_string_fields, $fields );
 	}
 

--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -175,7 +175,7 @@ class Tiny_Nav_Menu_Cache {
             ? $_SERVER['REQUEST_URI']
             : ''; // WPCS: sanitization, input var OK.
 
-        return md5( "nav_menu-".$args->menu_id . $request_uri );
+        return md5( 'nav_menu-' . $args->menu_id . $request_uri );
     }
 }
 

--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -176,7 +176,7 @@ class Tiny_Nav_Menu_Cache {
             ? $_SERVER['REQUEST_URI']
             : ''; // WPCS: sanitization, input var OK.
 
-        return md5( wp_json_encode( $args ) . $request_uri );
+        return md5( "nav_menu-".$args->menu_id . $request_uri );
     }
 }
 

--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -51,8 +51,7 @@ class Tiny_Nav_Menu_Cache {
         add_action( 'split_shared_term', array( $this, 'flush_all' ) );
 
         // Learned from W3TC Page Cache rules and WP Super Cache rules
-        if ( is_user_logged_in() /* User is logged in */
-            || ! ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) /* Not a GET request */ // WPCS: input var OK.
+        if ( ! ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) /* Not a GET request */ // WPCS: input var OK.
             || ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) /* DO-NOT-CACHE tag present */
         ) {
             return;

--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -58,10 +58,10 @@ class Tiny_Nav_Menu_Cache {
 	// Add user-defined query parameters to the whitelist. Define the parameters you
 	// want whitelisted in wp-config in the following way:
 	//
-	// define('TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS', 'XDEBUG_TRIGGER, do_xhprof_profile');
+	// define('TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS', 'XDEBUG_TRIGGER|do_xhprof_profile');
 
 	if ( defined( 'TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS' ) ) {
-		$fields = array_map( 'trim', explode( ',', TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS) );
+		$fields = array_map( 'trim', explode( '|', TINY_NAV_CACHE_WHITELIST_QUERY_STRING_FIELDS) );
 		$this->whitelisted_query_string_fields = array_merge( $this->whitelisted_query_string_fields, $fields );
 	}
 

--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -49,7 +49,8 @@ class Tiny_Nav_Menu_Cache {
         add_action( 'split_shared_term', array( $this, 'flush_all' ) );
 
         // Learned from W3TC Page Cache rules and WP Super Cache rules
-        if ( ! ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) /* Not a GET request */ // WPCS: input var OK.
+	if ( is_user_logged_in() /* User is logged in */
+	    || ! ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) /* Not a GET request */ // WPCS: input var OK.
             || ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) /* DO-NOT-CACHE tag present */
         ) {
             return;

--- a/tiny-nav-menu-cache.php
+++ b/tiny-nav-menu-cache.php
@@ -28,6 +28,8 @@ class Tiny_Nav_Menu_Cache {
         'utm_medium',
         'utm_source',
         'utm_term',
+        'XDEBUG_TRIGGER',
+        'do_xhprof_profile',
     ];
 
     public function __construct() {


### PR DESCRIPTION
Hi,
Here are three fixes for the nav-menu cache :
1) add some parameters to whitelisted query-string parameters
2) ~~also cache for logged in users (otherwise, it may hide problems)~~
3) fix the cache key ($args changes between get_nav_menu and save_nav_menu, because wp_nav_menu sets $args->menu since WP 4.3).

Hope this helps!